### PR TITLE
Add Penner spin model to bounce physics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ TODO
 *.html
 examples/visualize_trajectory.cpp
 issues
+*_notes.md

--- a/include/physics_constants.hpp
+++ b/include/physics_constants.hpp
@@ -90,6 +90,9 @@ namespace physics_constants
     /// Pi constant (for MSVC compatibility where M_PI is not standard)
     constexpr float PI = 3.14159265358979323846F;
 
+    /// Standard golf ball radius (feet)
+    constexpr float STD_BALL_RADIUS_FT = STD_BALL_CIRCUMFERENCE_IN / (2.0F * PI) / INCHES_PER_FOOT;
+
     // ========================================================================
     // ANGULAR CONVERSION FACTORS
     // ========================================================================


### PR DESCRIPTION
- Backspin now reduces tangent velocity on bounce
- This causes high-backspin shots (wedges) to "check" on landing.