### PR TITLE
fix(build): drop -ffast-math so NaN convergence guards hold on macOS (4.5.1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-project(golf VERSION 4.5.0 LANGUAGES CXX)
+project(golf VERSION 4.5.1 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -66,7 +66,13 @@ if(MSVC)
 else()
     # GCC/Clang flags
     set(CMAKE_CXX_FLAGS "-Wall -Wextra")
-    set(CMAKE_CXX_FLAGS_RELEASE "-O3 -ffast-math")
+    # No -ffast-math: it implies -ffinite-math-only, which lets the compiler
+    # assume NaN/Inf never occur and fold NaN comparisons to a constant. The
+    # convergence guards (FlightSimulator run loop + *Phase::isPhaseComplete)
+    # rely on IEEE semantics — `NaN <= height` must stay false so a poisoned
+    # trajectory never falsely "completes". Apple Clang folded it the other way,
+    # breaking the hang guards on macOS.
+    set(CMAKE_CXX_FLAGS_RELEASE "-O3")
 endif()
 
 # Code coverage option


### PR DESCRIPTION
## Problem

macOS CI failed on 4.5 Release:

```
72 - FlightSimulatorTest.NanModelThrowsInsteadOfHanging (Failed)
73 - FlightSimulatorTest.TrajectoryVariantAlsoGuardsAgainstHang (Failed)
```

## Cause

Release built with `-ffast-math` (CMakeLists.txt:69), which implies `-ffinite-math-only`. That lets the compiler assume NaN/Inf never occur and fold NaN comparisons to a constant.

The convergence guards from bd56488 depend on IEEE semantics: `NanAerodynamicModel` poisons the trajectory with NaN, so `AerialPhase::isPhaseComplete` does `NaN <= terrainHeight` → false → phase never completes → step cap fires → `runtime_error`. Apple Clang folded that compare the other way, so the phase "completed" early, no throw, `EXPECT_THROW` failed. Linux kept it false, so CI stayed green.

The same flag makes `std::isnan`/`isfinite` unreliable, so an explicit finite-check guard wouldn't be robust under it either. The design (safety guards that detect divergence via NaN) is incompatible with `-ffinite-math-only`.

## Fix

Drop `-ffast-math`, keep `-O3`. Bump to 4.5.1.