### PR TITLE
Release v4.6.1

### DIFF
--- a/include/DefaultRollModel.hpp
+++ b/include/DefaultRollModel.hpp
@@ -80,8 +80,10 @@ public:
 			newSpin = {0.0F, 0.0F, 0.0F};
 		}
 
+		const float oldHorizontal = std::sqrt(oldVelX * oldVelX + oldVelY * oldVelY);
 		const float vHorizontal = std::sqrt(newVel[0] * newVel[0] + newVel[1] * newVel[1]);
-		const bool atRest = vHorizontal < STOPPING_VELOCITY;
+		const bool atRest = vHorizontal < STOPPING_VELOCITY &&
+			vHorizontal <= oldHorizontal;
 
 		return RollResult{newPos, newVel, newSpin, atRest};
 	}

--- a/src/FlightPhase.cpp
+++ b/src/FlightPhase.cpp
@@ -148,8 +148,6 @@ void AerialPhase::initialize(BallState &state)
 
 void AerialPhase::calculateStep(BallState &state, float dt)
 {
-	state.currentTime += dt;
-
 	// Spin decay uses the velocity from the previous step (v is still current).
 	// Exponential model: torque opposing spin is proportional to spin rate itself.
 	// All components decay uniformly — axis direction is preserved.
@@ -164,6 +162,7 @@ void AerialPhase::calculateStep(BallState &state, float dt)
 	// just-decayed spin held in stepSpin.
 	*stepSpin = state.spinVector;
 	integrator->step(state, dt, accelField);
+	state.currentTime += dt;
 
 	v    = math_utils::magnitude(state.velocity);
 	vMph = v / physics_constants::MPH_TO_FT_PER_S;

--- a/test/test_default_roll_model.cpp
+++ b/test/test_default_roll_model.cpp
@@ -160,6 +160,7 @@ TEST(DefaultRollModelTest, NearZeroSlopeStartGetsAccelerated)
     // Velocity below STOPPING_VELOCITY: sign-flip clamp must NOT kick in,
     // so gravity along slope can grow it.
     EXPECT_GT(result.newVelocity[1], 0.02F);
+    EXPECT_FALSE(result.atRest);
 }
 
 TEST(DefaultRollModelTest, SpinDecaysButPreservesAxis)

--- a/test/test_flight_simulator.cpp
+++ b/test/test_flight_simulator.cpp
@@ -90,6 +90,25 @@ namespace
 	private:
 		std::shared_ptr<int> calls_;
 	};
+
+	class FirstStepTimeIntegrator : public Integrator
+	{
+	public:
+		explicit FirstStepTimeIntegrator(std::shared_ptr<float> firstTime)
+			: firstTime_(std::move(firstTime)) {}
+
+		void step(BallState &state, float dt, const AccelerationField &accel) const override
+		{
+			if (std::isnan(*firstTime_))
+			{
+				*firstTime_ = state.currentTime;
+			}
+			DefaultIntegrator{}.step(state, dt, accel);
+		}
+
+	private:
+		std::shared_ptr<float> firstTime_;
+	};
 }
 
 class FlightSimulatorTest : public ::testing::Test
@@ -169,6 +188,20 @@ TEST_F(FlightSimulatorTest, CustomIntegratorDrivesTheFlightSteps)
 	// The injected integrator must have advanced the aerial/bounce steps.
 	EXPECT_GT(*calls, 0);
 	EXPECT_STREQ(sim.getCurrentPhaseName(), "complete");
+}
+
+TEST_F(FlightSimulatorTest, CustomIntegratorReceivesStartOfStepTime)
+{
+	auto firstTime = std::make_shared<float>(std::numeric_limits<float>::quiet_NaN());
+	FlightSimulator sim(ball, atmos, ground,
+	                    /*aero*/ nullptr, /*bounce*/ nullptr, /*roll*/ nullptr,
+	                    /*ball*/ BallProperties{},
+	                    physics_constants::GRAVITY_FT_PER_S2,
+	                    std::make_shared<FirstStepTimeIntegrator>(firstTime));
+
+	sim.run(0.01F);
+
+	EXPECT_FLOAT_EQ(*firstTime, 0.0F);
 }
 
 TEST_F(FlightSimulatorTest, GravityParameterAffectsFlight)


### PR DESCRIPTION
## Summary
- Fix roll rest detection so low-speed balls that are still accelerating downhill do not prematurely end the roll phase.
- Fix aerial phase timing so custom integrators receive the documented start-of-step `currentTime`, matching bounce phase behavior.
- Add regression coverage for downhill roll continuation and custom integrator timing.

## Verification
- `cmake --build build --target libgolf_tests && ./build/libgolf_tests`
- 133 tests passed.